### PR TITLE
fix the identifier variable

### DIFF
--- a/md.yaml
+++ b/md.yaml
@@ -13,7 +13,7 @@ security:
 x-google-ratelimit: 
   - name: md
     rate-literal: 10pm
-    identifier-ref: request.header.url
+    identifier-ref: request.url
     
 paths:
   '/':


### PR DESCRIPTION
fixed `request.header.url` to `request.url`. [Source](https://cloud.google.com/apigee/docs/api-platform/reference/variables-reference#request)